### PR TITLE
set matplotlib to use non-interactive backend in plotters.py

### DIFF
--- a/RL_helpers/plotters.py
+++ b/RL_helpers/plotters.py
@@ -1,10 +1,10 @@
+import os
 import pandas as pd
 import seaborn as sns
 import matplotlib
 
 matplotlib.use("Agg")
-import matplotlib.pyplot as plt
-import os
+import matplotlib.pyplot as plt  # noqa: E402
 
 
 def plot_comparison(

--- a/RL_helpers/plotters.py
+++ b/RL_helpers/plotters.py
@@ -1,5 +1,7 @@
 import pandas as pd
 import seaborn as sns
+import matplotlib
+matplotlib.use("Agg")  # <- Use a non-interactive backend
 import matplotlib.pyplot as plt
 import os
 

--- a/RL_helpers/plotters.py
+++ b/RL_helpers/plotters.py
@@ -1,7 +1,8 @@
 import pandas as pd
 import seaborn as sns
 import matplotlib
-matplotlib.use("Agg")  # <- Use a non-interactive backend
+
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import os
 


### PR DESCRIPTION
This warning can be safely avoided by forcing Matplotlib to use a non-GUI backend, "Agg".

Fixes #31 